### PR TITLE
fix Packagecloud bash script url

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -58,7 +58,7 @@ sudo apt-get update
 echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
 sudo apt-get install -y oracle-java7-installer
 
-curl https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash
+curl https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | sudo bash
 
 sudo apt-get install -y riak
 


### PR DESCRIPTION
This pull request fixes the following error.

```
==> default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> default:                                  Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   135    0   135    0     0    218      0 --:--:-- --:--:-- --:--:--   294
==> default: bash: line 1: syntax error near unexpected token `<'
==> default: bash: line 1: `<html><body>You are being <a href="https://packagecloud.io/install/repositories/basho/riak/script.deb.sh">redirected</a>.</body></html>'
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: 
==> default: Reading state information...
==> default: E: Unable to locate package riak
==> default: Reading package lists...
==> default: Building dependency tree...
==> default: 
==> default: Reading state information...
==> default: 0 upgraded, 0 newly installed, 0 to remove and 181 not upgraded.
==> default: /tmp/vagrant-shell: line 67: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 68: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 69: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 70: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 71: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 72: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 73: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 74: /etc/riak/riak.conf: No such file or directory
==> default: 65536
==> default: /tmp/vagrant-shell: line 75: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 76: /etc/riak/riak.conf: No such file or directory
==> default: /tmp/vagrant-shell: line 80: riak: command not found
==> default: /tmp/vagrant-shell: line 82: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 83: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 84: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 85: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 86: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 88: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 89: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 91: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 92: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 94: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 99: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 100: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 101: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 102: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 103: riak-admin: command not found
==> default: /tmp/vagrant-shell: line 105: riak: command not found
```